### PR TITLE
add a new stage for meshtasticd

### DIFF
--- a/config_rak_meshtasticd
+++ b/config_rak_meshtasticd
@@ -1,0 +1,20 @@
+NAME="RAKPiOS"
+VERSION=0.9.3-meshtasticd-0.0.1
+ARCH=arm64
+RELEASE=bookworm
+
+IMG_NAME="${NAME,,}-${VERSION}-${ARCH}"
+PI_GEN_RELEASE="${NAME,,}-${VERSION}-${RELEASE}"
+TARGET_HOSTNAME="${NAME,,}"
+IMG_DATE=$( date +%Y%m%d )
+ARCHIVE_FILENAME="${IMG_DATE}-${IMG_NAME}"
+FIRST_USER_NAME=rak
+FIRST_USER_PASS=changeme
+DISABLE_FIRST_BOOT_USER_RENAME=1
+ENABLE_SSH=1
+STAGE_LIST="stage0 stage1 stage2 stage2-rak stage2-rak6421-meshtasticd"
+
+PI_GEN_REPO=https://github.com/RAKWireless/rakpios
+KERNEL_BUILD=0
+KERNEL_CACHED=0
+KERNEL_TAG=rpi-6.12.y

--- a/stage2-rak6421-meshtasticd/00-base/01-run.sh
+++ b/stage2-rak6421-meshtasticd/00-base/01-run.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+# Update config.txt for RAK6421
+install -m 755 files/config.txt "${ROOTFS_DIR}/boot/firmware/"
+
+# Remove serial console from cmdline.txt to free up serial port for RAK12501 GPS module
+sed -i "s/console=serial0,115200 //g" "${ROOTFS_DIR}/boot/firmware/cmdline.txt"
+
+# Install meshtasticd
+on_chroot << EOF
+# Add Meshtastic repository
+echo 'deb http://download.opensuse.org/repositories/network:/Meshtastic:/beta/Debian_12/ /' > /etc/apt/sources.list.d/network:Meshtastic:beta.list
+
+# Add GPG key
+curl -fsSL https://download.opensuse.org/repositories/network:Meshtastic:beta/Debian_12/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/network_Meshtastic_beta.gpg
+
+# Update and install meshtasticd
+apt update
+apt install -y meshtasticd
+EOF
+
+# Install Python CLI
+on_chroot << EOF
+pip3 install --break-system-packages --upgrade pytap2
+pip3 install --break-system-packages --upgrade "meshtastic[cli]"
+EOF
+
+# Configure meshtasticd - uncomment Webserver Port
+on_chroot << EOF
+sed -i 's/^#  Port: 9443/  Port: 9443/' /etc/meshtasticd/config.yaml
+EOF
+

--- a/stage2-rak6421-meshtasticd/00-base/files/config.txt
+++ b/stage2-rak6421-meshtasticd/00-base/files/config.txt
@@ -1,0 +1,78 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# Uncomment to overclock the CPU. 700 MHz is the default.
+# arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+dtparam=i2c_arm=on
+# dtparam=i2s=on
+dtparam=spi=on
+
+# Enable Pi-HAT EEPROM (this is specific to the RAK6421)
+dtparam=i2c_vc=on
+dtoverlay=i2c0
+
+# Enable uart (this is for GPS module)
+enable_uart=1
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Additional overlays and parameters are documented
+# /boot/firmware/overlays/README
+
+# Automatically load overlays for detected cameras
+# camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Don't have the firmware create an initial video= setting in cmdline.txt.
+# Use the kernel's default instead.
+disable_fw_kms_setup=1
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+# Run as fast as firmware / board allows
+arm_boost=1
+
+# Enable onboard RTC (this is specific to the RAK7391)
+# dtoverlay=i2c-rtc,pcf85063a
+
+# Enable onboard GPIO Expander TPT29555 (compatible with PCA9555,this is specific to the RAK7391)
+# dtoverlay=rak7391
+
+# Enable onboard ADS1115 (this is specific to the RAK7391)
+# dtoverlay=ads1115
+# dtparam=cha_enable
+# dtparam=chb_enable
+# dtparam=chc_enable
+# dtparam=chd_enable
+# dtparam=i2c_arm_baudrate=400000
+
+# Antenna setting, values:
+#   ant1: PCB antenna (default)
+#   ant2: External antenna
+#   noant: Disable both antennas
+# dtparam=ant1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[cm5]
+dtoverlay=dwc2,dr_mode=host
+
+[all]

--- a/stage2-rak6421-meshtasticd/EXPORT_IMAGE
+++ b/stage2-rak6421-meshtasticd/EXPORT_IMAGE
@@ -1,0 +1,4 @@
+IMG_SUFFIX="-lite"
+if [ "${USE_QEMU}" = "1" ]; then
+	export IMG_SUFFIX="${IMG_SUFFIX}-qemu"
+fi

--- a/stage2-rak6421-meshtasticd/prerun.sh
+++ b/stage2-rak6421-meshtasticd/prerun.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+if [ ! -d "${ROOTFS_DIR}" ]; then
+	copy_previous
+fi


### PR DESCRIPTION
# Merge Request: release-0.9.3-meshtasticd

## Summary
Add a new build stage for Meshtastic on RAK6421 (meshtasticd).

## Changes
- Add `config_rak_meshtasticd` configuration
- Add stage `stage2-rak6421-meshtasticd` with:
  - Base packages and `01-run.sh`
  - `config.txt` for the stage
  - `EXPORT_IMAGE` and `prerun.sh`

## Target branch
`release-0.9.3-meshtasticd` (or adjust as needed)

## Testing
- [ ☑] Image builds successfully with the new stage
- [ ☑] meshtasticd runs as expected on RAK6421